### PR TITLE
feat: add fonts and a theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'ui/screens/home_screen.dart';
 import 'ui/screens/map_screen.dart';
 import 'ui/screens/settings_screen.dart';
+import 'ui/theme/theme.dart';
 
 void main() => runApp(MyApp());
 
@@ -10,10 +11,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter App',
-      theme: ThemeData(
-        useMaterial3: false,
-        primarySwatch: Colors.blue,
-      ),
+      theme: AppTheme.lightTheme,
       home: MainScreen(),
     );
   }

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -1,12 +1,15 @@
 import 'package:BabBBu/ui/assets/assets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import '../theme/colors.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       appBar: AppBar(
         title: Text('Home'),
@@ -48,6 +51,16 @@ class HomeScreen extends StatelessWidget {
               child: SvgPicture.asset(
                 AppAssets.icons.arrowLine,
               ),
+            ),
+            Text(
+              'It is a title',
+              style: textTheme.titleLarge!.copyWith(
+                color: AppColors.primaryOrange600,
+              ),
+            ),
+            Text(
+              'Welcome to Home Screen!',
+              style: textTheme.bodyLarge,
             ),
           ],
         ),

--- a/lib/ui/theme/fonts.dart
+++ b/lib/ui/theme/fonts.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+
+class AppTextStyles {
+  static TextStyle _baseTextStyle({
+    required double fontSize,
+    required double height,
+    required FontWeight fontWeight,
+  }) {
+    return TextStyle(
+      fontSize: fontSize,
+      height: height / fontSize, // 줄 높이를 비율로 계산
+      fontWeight: fontWeight,
+      fontFamily: 'Pretendard', // 공통 폰트 패밀리
+    );
+  }
+
+  // Title 1 (24px / 32px)
+  static TextStyle title1Bold =
+      _baseTextStyle(fontSize: 24, height: 32, fontWeight: FontWeight.w700);
+  static TextStyle title1Semibold =
+      _baseTextStyle(fontSize: 24, height: 32, fontWeight: FontWeight.w600);
+  static TextStyle title1Medium =
+      _baseTextStyle(fontSize: 24, height: 32, fontWeight: FontWeight.w500);
+  static TextStyle title1Regular =
+      _baseTextStyle(fontSize: 24, height: 32, fontWeight: FontWeight.w400);
+  static TextStyle title1Light =
+      _baseTextStyle(fontSize: 24, height: 32, fontWeight: FontWeight.w300);
+
+  // Title 2 (22px / 28px)
+  static TextStyle title2Bold =
+      _baseTextStyle(fontSize: 22, height: 28, fontWeight: FontWeight.w700);
+  static TextStyle title2Semibold =
+      _baseTextStyle(fontSize: 22, height: 28, fontWeight: FontWeight.w600);
+  static TextStyle title2Medium =
+      _baseTextStyle(fontSize: 22, height: 28, fontWeight: FontWeight.w500);
+  static TextStyle title2Regular =
+      _baseTextStyle(fontSize: 22, height: 28, fontWeight: FontWeight.w400);
+  static TextStyle title2Light =
+      _baseTextStyle(fontSize: 22, height: 28, fontWeight: FontWeight.w300);
+
+  // Heading 1 (20px / 26px)
+  static TextStyle heading1Bold =
+      _baseTextStyle(fontSize: 20, height: 26, fontWeight: FontWeight.w700);
+  static TextStyle heading1Semibold =
+      _baseTextStyle(fontSize: 20, height: 26, fontWeight: FontWeight.w600);
+  static TextStyle heading1Medium =
+      _baseTextStyle(fontSize: 20, height: 26, fontWeight: FontWeight.w500);
+  static TextStyle heading1Regular =
+      _baseTextStyle(fontSize: 20, height: 26, fontWeight: FontWeight.w400);
+  static TextStyle heading1Light =
+      _baseTextStyle(fontSize: 20, height: 26, fontWeight: FontWeight.w300);
+
+  // Heading 2 (18px / 24px)
+  static TextStyle heading2Bold =
+      _baseTextStyle(fontSize: 18, height: 24, fontWeight: FontWeight.w700);
+  static TextStyle heading2Semibold =
+      _baseTextStyle(fontSize: 18, height: 24, fontWeight: FontWeight.w600);
+  static TextStyle heading2Medium =
+      _baseTextStyle(fontSize: 18, height: 24, fontWeight: FontWeight.w500);
+  static TextStyle heading2Regular =
+      _baseTextStyle(fontSize: 18, height: 24, fontWeight: FontWeight.w400);
+  static TextStyle heading2Light =
+      _baseTextStyle(fontSize: 18, height: 24, fontWeight: FontWeight.w300);
+
+  // Body 1 Normal (16px / 20px)
+  static TextStyle body1NormalBold =
+      _baseTextStyle(fontSize: 16, height: 20, fontWeight: FontWeight.w700);
+  static TextStyle body1NormalSemibold =
+      _baseTextStyle(fontSize: 16, height: 20, fontWeight: FontWeight.w600);
+  static TextStyle body1NormalMedium =
+      _baseTextStyle(fontSize: 16, height: 20, fontWeight: FontWeight.w500);
+  static TextStyle body1NormalRegular =
+      _baseTextStyle(fontSize: 16, height: 20, fontWeight: FontWeight.w400);
+  static TextStyle body1NormalLight =
+      _baseTextStyle(fontSize: 16, height: 20, fontWeight: FontWeight.w300);
+
+  // Body 1 Reading (16px / 22px)
+  static TextStyle body1ReadingBold =
+      _baseTextStyle(fontSize: 16, height: 22, fontWeight: FontWeight.w700);
+  static TextStyle body1ReadingSemibold =
+      _baseTextStyle(fontSize: 16, height: 22, fontWeight: FontWeight.w600);
+  static TextStyle body1ReadingMedium =
+      _baseTextStyle(fontSize: 16, height: 22, fontWeight: FontWeight.w500);
+  static TextStyle body1ReadingRegular =
+      _baseTextStyle(fontSize: 16, height: 22, fontWeight: FontWeight.w400);
+  static TextStyle body1ReadingLight =
+      _baseTextStyle(fontSize: 16, height: 22, fontWeight: FontWeight.w300);
+
+  // Body 2 Normal (14px / 20px)
+  static TextStyle body2NormalBold =
+      _baseTextStyle(fontSize: 14, height: 20, fontWeight: FontWeight.w700);
+  static TextStyle body2NormalSemibold =
+      _baseTextStyle(fontSize: 14, height: 20, fontWeight: FontWeight.w600);
+  static TextStyle body2NormalMedium =
+      _baseTextStyle(fontSize: 14, height: 20, fontWeight: FontWeight.w500);
+  static TextStyle body2NormalRegular =
+      _baseTextStyle(fontSize: 14, height: 20, fontWeight: FontWeight.w400);
+  static TextStyle body2NormalLight =
+      _baseTextStyle(fontSize: 14, height: 20, fontWeight: FontWeight.w300);
+
+  // Body 2 Reading (14px / 22px)
+  static TextStyle body2ReadingBold =
+      _baseTextStyle(fontSize: 14, height: 22, fontWeight: FontWeight.w700);
+  static TextStyle body2ReadingSemibold =
+      _baseTextStyle(fontSize: 14, height: 22, fontWeight: FontWeight.w600);
+  static TextStyle body2ReadingMedium =
+      _baseTextStyle(fontSize: 14, height: 22, fontWeight: FontWeight.w500);
+  static TextStyle body2ReadingRegular =
+      _baseTextStyle(fontSize: 14, height: 22, fontWeight: FontWeight.w400);
+  static TextStyle body2ReadingLight =
+      _baseTextStyle(fontSize: 14, height: 22, fontWeight: FontWeight.w300);
+
+  // Label Normal (13px / 18px)
+  static TextStyle labelNormalBold =
+      _baseTextStyle(fontSize: 13, height: 18, fontWeight: FontWeight.w700);
+  static TextStyle labelNormalSemibold =
+      _baseTextStyle(fontSize: 13, height: 18, fontWeight: FontWeight.w600);
+  static TextStyle labelNormalMedium =
+      _baseTextStyle(fontSize: 13, height: 18, fontWeight: FontWeight.w500);
+  static TextStyle labelNormalRegular =
+      _baseTextStyle(fontSize: 13, height: 18, fontWeight: FontWeight.w400);
+  static TextStyle labelNormalLight =
+      _baseTextStyle(fontSize: 13, height: 18, fontWeight: FontWeight.w300);
+
+  // Label Reading (13px / 20px)
+  static TextStyle labelReadingBold =
+      _baseTextStyle(fontSize: 13, height: 20, fontWeight: FontWeight.w700);
+  static TextStyle labelReadingSemibold =
+      _baseTextStyle(fontSize: 13, height: 20, fontWeight: FontWeight.w600);
+  static TextStyle labelReadingMedium =
+      _baseTextStyle(fontSize: 13, height: 20, fontWeight: FontWeight.w500);
+  static TextStyle labelReadingRegular =
+      _baseTextStyle(fontSize: 13, height: 20, fontWeight: FontWeight.w400);
+  static TextStyle labelReadingLight =
+      _baseTextStyle(fontSize: 13, height: 20, fontWeight: FontWeight.w300);
+
+  // Caption Normal (12px / 18px)
+  static TextStyle captionNormalBold =
+      _baseTextStyle(fontSize: 12, height: 18, fontWeight: FontWeight.w700);
+  static TextStyle captionNormalSemibold =
+      _baseTextStyle(fontSize: 12, height: 18, fontWeight: FontWeight.w600);
+  static TextStyle captionNormalMedium =
+      _baseTextStyle(fontSize: 12, height: 18, fontWeight: FontWeight.w500);
+  static TextStyle captionNormalRegular =
+      _baseTextStyle(fontSize: 12, height: 18, fontWeight: FontWeight.w400);
+  static TextStyle captionNormalLight =
+      _baseTextStyle(fontSize: 12, height: 18, fontWeight: FontWeight.w300);
+
+  // Caption Reading (12px / 20px)
+  static TextStyle captionReadingBold =
+      _baseTextStyle(fontSize: 12, height: 20, fontWeight: FontWeight.w700);
+  static TextStyle captionReadingSemibold =
+      _baseTextStyle(fontSize: 12, height: 20, fontWeight: FontWeight.w600);
+  static TextStyle captionReadingMedium =
+      _baseTextStyle(fontSize: 12, height: 20, fontWeight: FontWeight.w500);
+  static TextStyle captionReadingRegular =
+      _baseTextStyle(fontSize: 12, height: 20, fontWeight: FontWeight.w400);
+  static TextStyle captionReadingLight =
+      _baseTextStyle(fontSize: 12, height: 20, fontWeight: FontWeight.w300);
+
+  static TextTheme get textTheme => TextTheme(
+      headlineLarge: title1Bold,
+      headlineMedium: title2Bold,
+      headlineSmall: heading1Bold,
+      titleLarge: heading1Bold,
+      titleMedium: heading2Bold,
+      titleSmall: body1NormalBold,
+      bodyLarge: body1NormalLight,
+      bodyMedium: body2NormalLight,
+      bodySmall: labelNormalLight,
+      labelLarge: labelReadingLight,
+      labelMedium: labelNormalLight);
+}

--- a/lib/ui/theme/theme.dart
+++ b/lib/ui/theme/theme.dart
@@ -1,0 +1,32 @@
+import 'colors.dart';
+import 'fonts.dart';
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static const _inputDecorationTheme = InputDecorationTheme(
+    hintStyle: TextStyle(
+      // text100 works for both light and dark themes
+      color: AppColors.text100,
+      fontSize: 18.0,
+      fontWeight: FontWeight.w400,
+    ),
+  );
+
+  static ThemeData lightTheme = ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.light,
+    // colorScheme: AppColors.lightColorScheme,
+    textTheme: AppTextStyles.textTheme,
+    inputDecorationTheme: _inputDecorationTheme,
+    extensions: [],
+  );
+
+  static ThemeData darkTheme = ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    // colorScheme: AppColors.darkColorScheme,
+    textTheme: AppTextStyles.textTheme,
+    inputDecorationTheme: _inputDecorationTheme,
+    extensions: [],
+  );
+}


### PR DESCRIPTION
## 목적
* Figma 내 fonts를 추가하자

## 과정
###### 1. fonts 추가 : ui/theme/fonts.dart
* Figma 내 fonts 추가
###### 2. Theme의 textTheme 필드를 사용 : ui/theme/theme.dart
* Theme의 textTheme 필드 내 아래 속성들에 fonts를 매핑하면 폰트 통일감 있게 개발 가능
* Theme는 희진님이 주신 링크 내 [theme.dart 파일](https://github.com/flutter/samples/blob/35787ba95c819c8a6c75dd05a0c1aab09a66ba73/compass_app/app/lib/ui/core/themes/theme.dart)을 참고

```
  const TextTheme({
    this.displayLarge,
    this.displayMedium,
    this.displaySmall,
    this.headlineLarge,
    this.headlineMedium,
    this.headlineSmall,
    this.titleLarge,
    this.titleMedium,
    this.titleSmall,
    this.bodyLarge,
    this.bodyMedium,
    this.bodySmall,
    this.labelLarge,
    this.labelMedium,
    this.labelSmall,
  });
```

## 미리보기
* 아래 처럼 Pretendard 글꼴이 적용 됨
![image](https://github.com/user-attachments/assets/b9737f5f-6ece-4471-8d1e-d11cd1c250ed)

## To Do
* color도 colorScheme을 사용하면 좋을듯?
* 희진님이 주신 링크 내 [theme.dart 파일](https://github.com/flutter/samples/blob/35787ba95c819c8a6c75dd05a0c1aab09a66ba73/compass_app/app/lib/ui/core/themes/theme.dart)의 `colorScheme: AppColors.lightColorScheme,` 부분 참고